### PR TITLE
add go path

### DIFF
--- a/dot.zshrc
+++ b/dot.zshrc
@@ -149,9 +149,11 @@ function precmd {
 export PATH="/usr/local/opt/node@8/bin:$PATH"
 
 # Go path for macOS
-export GOPATH=$HOME/go
-export GOROOT=/usr/local/opt/go/libexec
-export PATH=$PATH:${GOPATH}/bin:${GOROOT}/bin
+if [[ "$(uname)" == 'Darwin' ]]; then
+    export GOPATH=$HOME/go
+    export GOROOT=/usr/local/opt/go/libexec
+    export PATH=$PATH:${GOPATH}/bin:${GOROOT}/bin
+fi
 
 # tramp mode for zsh: https://www.gnu.org/software/tramp/tramp-emacs.html
 [ $TERM = "dumb" ] && unsetopt zle && PS1='$ '


### PR DESCRIPTION
only use for macOS
first create local workspace `mkdir $HOME/go`
or if you'd like to use a different directory, you will need to set the GOPATH environment variable.